### PR TITLE
Actualizada parametrización de SoapClient

### DIFF
--- a/src/Cotizaciones.php
+++ b/src/Cotizaciones.php
@@ -6,15 +6,17 @@ use DateTime;
 use Exception;
 use SoapClient;
 
-class Cotizaciones {
-
-    public static function obtenerUltimoCierre() {
+class Cotizaciones
+{
+    public static function obtenerUltimoCierre()
+    {
         $conexion = self::getSoapClient('awsultimocierre');
         $resultado = $conexion->Execute();
         return $resultado->Salida->Fecha;
     }
 
-    public static function obtenerCotizacion($fecha = null, $moneda = 2225, $grupo = 0) {
+    public static function obtenerCotizacion($fecha = null, $moneda = 2225, $grupo = 0)
+    {
         if (isset($fecha)) {
             if (!DateTime::createFromFormat('Y-m-d', $fecha)) {
                 throw new Exception("Formato de fecha no es AAAA-MM-DD");
@@ -29,7 +31,7 @@ class Cotizaciones {
                 'FechaHasta' => $fecha,
                 'Grupo' => $grupo,
                 'Moneda' => ['item' => $moneda],
-            ]
+            ],
         ];
 
         $client = self::getSoapClient('awsbcucotizaciones');
@@ -38,18 +40,8 @@ class Cotizaciones {
         return $response->Salida->datoscotizaciones->{'datoscotizaciones.dato'}->TCC;
     }
 
-    private static function getSoapClient($ws) {
-        $options = [
-            'cache_wsdl' => WSDL_CACHE_NONE,
-            'stream_context' => stream_context_create([
-                'ssl' => [
-                    'verify_peer' => FALSE,
-                    'verify_peer_name' => FALSE,
-                    'crypto_method' => STREAM_CRYPTO_METHOD_TLS_CLIENT
-                ]
-            ])
-        ];
-        return new SoapClient("https://cotizaciones.bcu.gub.uy/wscotizaciones/servlet/$ws?wsdl", $options);
+    private static function getSoapClient($ws)
+    {
+        return new SoapClient("https://cotizaciones.bcu.gub.uy/wscotizaciones/servlet/$ws?wsdl");
     }
-
 }


### PR DESCRIPTION
El BCU antes tenía inválido el certificado SSL, por lo que era necesario desactivar una serie de opciones en la configuración de la conexión.
Parece que el certificado quedó al día por lo que esta parametrización ya no es necesaria.