### PR TITLE
Corregido formato de salida de cotizaciones desde cache

### DIFF
--- a/src/Cotizaciones.php
+++ b/src/Cotizaciones.php
@@ -15,7 +15,7 @@ class Cotizaciones
         return $resultado->Salida->Fecha;
     }
 
-    public static function obtenerCotizacion($fecha = null, $moneda = 2225, $grupo = 0)
+    public static function obtenerCotizacion($fecha = null, $moneda = 2225, $grupo = 0): float
     {
         if (isset($fecha)) {
             if (!DateTime::createFromFormat('Y-m-d', $fecha)) {


### PR DESCRIPTION
Al encontrar una cotización en el cache, se traía como string y no como float.
Esto puede provocar problemas en integraciones y tests, por lo que se homogeiniza la salida.