### PR TITLE
Agregado caché para obtención de fecha de último cierre

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.4
+
     - uses: actions/checkout@v1
 
     - name: Validate composer.json and composer.lock

--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/Cotizaciones.php
+++ b/src/Cotizaciones.php
@@ -8,14 +8,9 @@ use SoapClient;
 
 class Cotizaciones
 {
-    public static function obtenerUltimoCierre()
-    {
-        $conexion = self::getSoapClient('awsultimocierre');
-        $resultado = $conexion->Execute();
-        return $resultado->Salida->Fecha;
-    }
+    use WsBcu;
 
-    public static function obtenerCotizacion($fecha = null, $moneda = 2225, $grupo = 0): float
+    public static function obtener($fecha = null, $moneda = 2225, $grupo = 0): float
     {
         if (isset($fecha)) {
             if (!DateTime::createFromFormat('Y-m-d', $fecha)) {
@@ -47,17 +42,6 @@ class Cotizaciones
         self::cachePut($fecha, $moneda, $grupo, $cotizacion);
 
         return $cotizacion;
-    }
-
-    private static function getSoapClient($ws)
-    {
-        $options = [
-            'stream_context' => stream_context_create([
-                'ssl' => ['cafile' => __DIR__ . "/../cacert.pem"],
-            ]),
-        ];
-
-        return new SoapClient("https://cotizaciones.bcu.gub.uy/wscotizaciones/servlet/$ws?wsdl", $options);
     }
 
     private static function cacheGet(string $fecha, int $moneda, int $grupo)

--- a/src/UltimoCierre.php
+++ b/src/UltimoCierre.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace biller\bcu;
+
+class UltimoCierre
+{
+    use WsBcu;
+
+    public static function obtener($cache = true): string
+    {
+        if ($cache && ($fecha = self::cacheGet())) {
+            return $fecha;
+        }
+
+        $conexion = self::getSoapClient('awsultimocierre');
+        $resultado = $conexion->Execute();
+        $fecha = $resultado->Salida->Fecha;
+
+        if ($cache) {
+            self::cachePut($fecha);
+        }
+
+        return $fecha;
+    }
+
+    private static function cacheGet()
+    {
+        $path = __DIR__ . "/../cache/ultimo_cierre.txt";
+
+        if (!file_exists($path)) {
+            return false;
+        }
+
+        $fecha = file_get_contents($path);
+        if ($fecha == date('Y-m-d', strtotime('-3 hours'))) {
+            return $fecha;
+        }
+
+        $modificacion = filemtime($path);
+        if (strtotime('-30 minutes') < $modificacion) {
+            return $fecha;
+        }
+
+        return false;
+    }
+
+    private static function cachePut($fecha)
+    {
+        $path = __DIR__ . "/../cache/ultimo_cierre.txt";
+        file_put_contents($path, $fecha);
+    }
+}

--- a/src/WsBcu.php
+++ b/src/WsBcu.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace biller\bcu;
+
+use SoapClient;
+
+trait WsBcu
+{
+    private static function getSoapClient($ws)
+    {
+        $options = [
+            'stream_context' => stream_context_create([
+                'ssl' => ['cafile' => __DIR__ . "/../cacert.pem"],
+            ]),
+        ];
+
+        return new SoapClient("https://cotizaciones.bcu.gub.uy/wscotizaciones/servlet/$ws?wsdl", $options);
+    }
+}

--- a/tests/unit/CotizacionesTest.php
+++ b/tests/unit/CotizacionesTest.php
@@ -12,7 +12,7 @@ class CotizacionesTest extends Unit
 
     public function testObtenerCotizacion()
     {
-        $cotizacion = Cotizaciones::obtenerCotizacion('2019-07-16');
+        $cotizacion = Cotizaciones::obtener('2019-07-16');
         $this->tester->assertEquals(35.165, $cotizacion);
     }
 }

--- a/tests/unit/UltimoCierreTest.php
+++ b/tests/unit/UltimoCierreTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace unit;
+
+use biller\bcu\UltimoCierre;
+use UnitTester;
+
+class UltimoCierreTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var UnitTester
+     */
+    protected $tester;
+
+    public function testObtener()
+    {
+        $fecha = UltimoCierre::obtener();
+        $this->tester->assertRegExp('/\d{4}-\d{2}-\d{2}/', $fecha);
+    }
+
+    public function testObtenerSinCache()
+    {
+        $fecha = UltimoCierre::obtener(false);
+        $this->tester->assertRegExp('/\d{4}-\d{2}-\d{2}/', $fecha);
+    }
+}


### PR DESCRIPTION
- Al obtener la fecha de ultimo cierre se almacena en el filesystem local
- Cuando se solicita nuevamente se devuelve valor cacheado si
  - Fecha de ultimo cierre almacenado es hoy O
  - Ultimo llamado al BCU se hizo hace menos de 30 minutos